### PR TITLE
Feature/test client tuned

### DIFF
--- a/c++-virtan/server.cc
+++ b/c++-virtan/server.cc
@@ -9,49 +9,64 @@
 #include <cstdlib>
 #include <boost/asio.hpp>
 
+namespace {
+
 template <typename Context>
-void* allocate(std::size_t size, Context& context) {
+void* allocate(std::size_t size, Context& context)
+{
   using namespace boost::asio;
   return asio_handler_allocate(size, std::addressof(context));
 }
 
 template <typename Context>
-void deallocate(void* pointer, std::size_t size, Context& context) {
+void deallocate(void* pointer, std::size_t size, Context& context)
+{
   using namespace boost::asio;
   asio_handler_deallocate(pointer, size, std::addressof(context));
 }
 
 template <typename Function, typename Context>
-void invoke(Function&& function, Context& context) {
+void invoke(Function&& function, Context& context)
+{
   using namespace boost::asio;
-  asio_handler_invoke(std::forward<Function>(function), std::addressof(context));
+  asio_handler_invoke(std::forward<Function>(function),
+      std::addressof(context));
 }
 
 template <std::size_t alloc_size>
-class handler_allocator {
+class handler_allocator
+{
 private:
   handler_allocator(const handler_allocator&) = delete;
+
   handler_allocator& operator=(const handler_allocator&) = delete;
 
 public:
-  handler_allocator() : in_use_(false) {}
+  handler_allocator() : in_use_(false)
+  {}
+
   ~handler_allocator() = default;
 
-  bool owns(void* p) const {
+  bool owns(void* p) const
+  {
     return std::addressof(storage_) == p;
   }
 
-  void* allocate(std::size_t size) {
-    if (in_use_ || size > alloc_size) {
-        return 0;
+  void* allocate(std::size_t size)
+  {
+    if (in_use_ || size > alloc_size)
+    {
+      return 0;
     }
     in_use_ = true;
     return std::addressof(storage_);
   }
 
-  void deallocate(void* p) {
-    if (p) {
-        in_use_ = false;
+  void deallocate(void* p)
+  {
+    if (p)
+    {
+      in_use_ = false;
     }
   }
 
@@ -61,7 +76,8 @@ private:
 };
 
 template <typename Allocator, typename Handler>
-class custom_alloc_handler {
+class custom_alloc_handler
+{
 private:
   typedef custom_alloc_handler<Allocator, Handler> this_type;
 
@@ -70,45 +86,58 @@ public:
 
   template <typename H>
   custom_alloc_handler(Allocator& allocator, H&& handler):
-    allocator_(std::addressof(allocator)), handler_(std::forward<H>(handler)) {}
+      allocator_(std::addressof(allocator)), handler_(std::forward<H>(handler))
+  {}
 
-  friend void* asio_handler_allocate(std::size_t size, this_type* context) {
-    if (void* p = context->allocator_->allocate(size)) {
+  friend void* asio_handler_allocate(std::size_t size, this_type* context)
+  {
+    if (void* p = context->allocator_->allocate(size))
+    {
       return p;
     }
     return allocate(size, context->handler_);
   }
 
-  friend void asio_handler_deallocate(void* pointer, std::size_t size, this_type* context) {
-    if (context->allocator_->owns(pointer)) {
+  friend void
+  asio_handler_deallocate(void* pointer, std::size_t size, this_type* context)
+  {
+    if (context->allocator_->owns(pointer))
+    {
       context->allocator_->deallocate(pointer);
-    } else {
+    }
+    else
+    {
       deallocate(pointer, size, context->handler_);
     }
   }
 
   template <typename Function>
-  friend void asio_handler_invoke(Function&& function, this_type* context) {
+  friend void asio_handler_invoke(Function&& function, this_type* context)
+  {
     invoke(std::forward<Function>(function), context->handler_);
   }
 
   template <typename Function>
-  friend void asio_handler_invoke(Function& function, this_type* context) {
+  friend void asio_handler_invoke(Function& function, this_type* context)
+  {
     invoke(function, context->handler_);
   }
 
   template <typename Function>
-  friend void asio_handler_invoke(const Function& function, this_type* context) {
+  friend void asio_handler_invoke(const Function& function, this_type* context)
+  {
     invoke(function, context->handler_);
   }
 
   template <typename... Arg>
-  void operator()(Arg&&... arg) {
+  void operator()(Arg&& ... arg)
+  {
     handler_(std::forward<Arg>(arg)...);
   }
 
   template <typename... Arg>
-  void operator()(Arg&&... arg) const {
+  void operator()(Arg&& ... arg) const
+  {
     handler_(std::forward<Arg>(arg)...);
   }
 
@@ -119,80 +148,110 @@ private:
 
 template <typename Allocator, typename Handler>
 inline custom_alloc_handler<Allocator, typename std::decay<Handler>::type>
-make_custom_alloc_handler(Allocator& allocator, Handler&& handler) {
+make_custom_alloc_handler(Allocator& allocator, Handler&& handler)
+{
   typedef typename std::decay<Handler>::type handler_type;
-  return custom_alloc_handler<Allocator, handler_type>(allocator, std::forward<Handler>(handler));
+  return custom_alloc_handler<Allocator, handler_type>(allocator,
+      std::forward<Handler>(handler));
 }
 
-class connection {
+class connection
+{
 private:
   connection(const connection&) = delete;
+
   connection& operator=(const connection&) = delete;
 
 public:
-  explicit connection(boost::asio::io_service& service) : socket_(service) {}
+  explicit connection(boost::asio::io_service& service) : socket_(service)
+  {}
+
   ~connection() = default;
 
-  void start() {
+  void start()
+  {
     socket_.async_read_some(boost::asio::buffer(data_, max_length),
-        make_custom_alloc_handler(allocator_, std::bind(&connection::read, this,
-            std::placeholders::_1, std::placeholders::_2)));
+        make_custom_alloc_handler(allocator_,
+            std::bind(&connection::read, this, std::placeholders::_1,
+                std::placeholders::_2)));
   }
 
-  boost::asio::ip::tcp::socket& socket() {
+  boost::asio::ip::tcp::socket& socket()
+  {
     return socket_;
   }
 
 private:
-  void read(const boost::system::error_code& e, std::size_t bytes_transferred) {
-    if (e) {
+  void read(const boost::system::error_code& e, std::size_t bytes_transferred)
+  {
+    if (e)
+    {
       delete this;
-    } else {
-      boost::asio::async_write(socket_, boost::asio::buffer(data_, bytes_transferred),
-          make_custom_alloc_handler(allocator_, std::bind(&connection::write, this,
-              std::placeholders::_1)));
+    }
+    else
+    {
+      boost::asio::async_write(socket_,
+          boost::asio::buffer(data_, bytes_transferred),
+          make_custom_alloc_handler(allocator_,
+              std::bind(&connection::write, this, std::placeholders::_1)));
     }
   }
 
-  void write(const boost::system::error_code &e) {
-    if (e) {
+  void write(const boost::system::error_code& e)
+  {
+    if (e)
+    {
       delete this;
-    } else {
+    }
+    else
+    {
       start();
     }
   }
 
   handler_allocator<128> allocator_;
-  enum { max_length = 4096 };
+  enum
+  {
+    max_length = 4096
+  };
   char data_[max_length];
   boost::asio::ip::tcp::socket socket_;
 };
 
-class acceptor {
+class acceptor
+{
 private:
   acceptor(const acceptor&) = delete;
+
   acceptor& operator=(const acceptor&) = delete;
 
 public:
   acceptor(boost::asio::io_service& service,
-      boost::asio::ip::tcp::acceptor::native_handle_type native_acceptor) :
-    service_(service), acceptor_(service_, boost::asio::ip::tcp::v4(), native_acceptor) {
+      boost::asio::ip::tcp::acceptor::native_handle_type native_acceptor)
+      : service_(service),
+      acceptor_(service_, boost::asio::ip::tcp::v4(), native_acceptor)
+  {
     start_accept();
   }
 
   ~acceptor() = default;
 
 private:
-  void start_accept() {
-    connection *c = new connection(service_);
+  void start_accept()
+  {
+    connection* c = new connection(service_);
     acceptor_.async_accept(c->socket(), make_custom_alloc_handler(allocator_,
         std::bind(&acceptor::accept, this, c, std::placeholders::_1)));
   }
 
-  void accept(connection *c, const boost::system::error_code& e) {
-    if (e) {
+  void accept(connection* c, const boost::system::error_code& e)
+  {
+    if (e)
+    {
       delete c;
-    } else {
+    }
+    else
+    {
       c->start();
     }
     start_accept();
@@ -202,6 +261,8 @@ private:
   boost::asio::ip::tcp::acceptor acceptor_;
   handler_allocator<256> allocator_;
 };
+
+} // anonymous namespace
 
 int main(int args, char** argv) {
   if(args < 2) {

--- a/c++-virtan/server.cc
+++ b/c++-virtan/server.cc
@@ -6,6 +6,7 @@
 #include <thread>
 #include <type_traits>
 #include <algorithm>
+#include <cstdlib>
 #include <boost/asio.hpp>
 
 template <typename Context>
@@ -205,7 +206,7 @@ private:
 int main(int args, char** argv) {
   if(args < 2) {
     std::cout << "Usage: " << argv[0] << " <port> [threads = 24]" << std::endl;
-    return 1;
+    return EXIT_FAILURE;
   }
   unsigned short port = std::atoi(argv[1]);
   std::size_t thread_num = args > 2 ? std::atoi(argv[2]) : 24;
@@ -223,5 +224,5 @@ int main(int args, char** argv) {
     });
   }
   std::for_each(threads.begin(), threads.end(), std::mem_fn(&std::thread::join));
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -5,6 +5,9 @@
 #include <functional>
 #include <thread>
 #include <chrono>
+#include <memory>
+#include <memory>
+#include <cstdlib>
 #include <boost/asio.hpp>
 
 const std::size_t clients_max = 10000;
@@ -12,198 +15,202 @@ const std::size_t bear_after_mcs = 1000;
 const std::size_t send_each_mcs = 10000;
 const std::size_t client_timeout_mcs = 30*1000*1000;
 
-std::size_t threads_;
-std::thread *vthreads;
-boost::asio::io_service *services;
-std::size_t services_i = 0;
+std::size_t thread_num;
+
+std::vector<std::unique_ptr<boost::asio::io_service>> services;
+std::atomic_size_t services_i(0);
 boost::asio::ip::tcp::resolver::iterator connect_to;
 
-volatile std::size_t children = 0;
-volatile std::size_t connection_active = 0;
-volatile std::size_t connection_errors = 0;
-volatile std::size_t exchange_errors = 0;
-volatile std::size_t connection_summ_mcs = 0;
-volatile std::size_t latency_summ_mcs = 0;
-volatile std::size_t msgs = 0;
+std::atomic_size_t children(0);
+std::atomic_size_t connection_active(0);
+std::atomic_size_t connection_errors(0);
+std::atomic_size_t exchange_errors(0);
+std::atomic_size_t connection_summ_mcs(0);
+std::atomic_size_t latency_summ_mcs(0);
+std::atomic_size_t msgs(0);
 
 class timer {
-    public:
-        timer() { reset(); }
+  public:
+    timer() {
+      reset(); 
+    }
 
-        void start() { gettimeofday(&start_time, NULL); }
+    void start() { 
+      gettimeofday(&start_time, NULL); 
+    }
 
-        std::size_t current() {
-            struct timeval now;
-            gettimeofday(&now, NULL);
-            std::size_t diff = (((std::size_t) now.tv_sec) * 1000000) + now.tv_usec - (((std::size_t) start_time.tv_sec) * 1000000) - start_time.tv_usec;
-            return diff;
-        }
+    std::size_t current() {
+      struct timeval now;
+      gettimeofday(&now, NULL);
+      std::size_t diff = (((std::size_t) now.tv_sec) * 1000000) + now.tv_usec - (((std::size_t) start_time.tv_sec) * 1000000) - start_time.tv_usec;
+      return diff;
+    }
 
-        void reset() {
-            start();
-        }
+    void reset() {
+      start();
+    }
 
-    private:
-        struct timeval start_time;
+  private:
+    struct timeval start_time;
 };
 
-void servicing(std::size_t i) {
-    boost::asio::io_service::work worker(services[i]);
-    services[i].run();
-}
-
 struct connection_handler {
-    connection_handler() :
-        service_id(__sync_fetch_and_add(&services_i, 1)),
-        my_service(services[service_id % threads_]),
-        s(my_service),
-        bear_tmr(my_service, boost::posix_time::microseconds(bear_after_mcs)),
-        exch_tmr(my_service),
-        errored(false)
-    {
-        if(service_id >= clients_max) return;
-        bear_tmr.async_wait(std::bind(&connection_handler::new_connection_handler, this, std::placeholders::_1));
-        connect_timer.reset();
-        __sync_fetch_and_add(&connection_active, 1);
-        async_connect(s, connect_to, std::bind(&connection_handler::connect, this, std::placeholders::_1));
+  connection_handler() :
+    service_id(++services_i),
+    my_service(*services[service_id % thread_num]),
+    s(my_service),
+    bear_tmr(my_service, boost::posix_time::microseconds(bear_after_mcs)),
+    exch_tmr(my_service),
+    errored(false)
+  {
+    if (service_id >= clients_max) {
+      return;
     }
+    bear_tmr.async_wait(std::bind(
+        &connection_handler::new_connection_handler, this, std::placeholders::_1));
+    connect_timer.reset();
+    ++connection_active;
+    async_connect(s, connect_to, std::bind(
+        &connection_handler::connect, this, std::placeholders::_1));
+  }
 
-    void new_connection_handler(const boost::system::error_code &e) {
-        // std::cout << "new connection\n";
-        assert(!e);
-        new connection_handler;
+  void new_connection_handler(const boost::system::error_code& e) {
+    assert(!e);
+    new connection_handler;
+  }
+
+  void connect(const boost::system::error_code& e) {
+    ++children;
+    --connection_active;
+    if (e) {
+      errored = true;
+      ++connection_errors;
+      return;
     }
-
-    void connect(const boost::system::error_code &e) {
-        // std::cout << "connect_staff\n";
-        __sync_fetch_and_add(&children, 1);
-        __sync_fetch_and_sub(&connection_active, 1);
-        if(e) {
-            errored = true;
-            __sync_fetch_and_add(&connection_errors, 1);
-            return;
-        }
-        std::size_t spent_mcs = connect_timer.current();
-        if(spent_mcs > client_timeout_mcs) {
-            errored = true;
-            __sync_fetch_and_add(&connection_errors, 1);
-            return;
-        }
-        __sync_fetch_and_add(&connection_summ_mcs, spent_mcs);
-        memset(send_buf, ' ', 32);
-        snprintf(send_buf, 32, "%d", rand());
-        send_buf[31] = '\n';
-        send_buf[32] = 0;
-        s.set_option(boost::asio::ip::tcp::no_delay(true));
-        //typedef boost::asio::detail::socket_option::integer<SOL_SOCKET, SO_SNDBUF> snd_buf;
-        //typedef boost::asio::detail::socket_option::integer<SOL_SOCKET, SO_RCVBUF> rcv_buf;
-        //s.set_option(snd_buf(18350));
-        //s.set_option(rcv_buf(18350));
-        read_staff(boost::system::error_code());
-        send_staff(boost::system::error_code());
+    std::size_t spent_mcs = connect_timer.current();
+    if (spent_mcs > client_timeout_mcs) {
+      errored = true;
+      ++connection_errors;
+      return;
     }
+    connection_summ_mcs += spent_mcs;
+    memset(send_buf, ' ', 32);
+    snprintf(send_buf, 32, "%d", rand());
+    send_buf[31] = '\n';
+    send_buf[32] = 0;
+    s.set_option(boost::asio::ip::tcp::no_delay(true));
+    read_staff(boost::system::error_code());
+    send_staff(boost::system::error_code());
+  }
 
-    void exchange(const boost::system::error_code &e) {
-        // std::cout << "exchange_staff\n";
-        assert(!e);
+  void send_staff(const boost::system::error_code& e) {
+    assert(!e);
+    if (errored) {
+      return;
     }
+    exch_tmr.expires_from_now(boost::posix_time::microseconds(rand() % (2 * send_each_mcs)));
+    exch_tmr.async_wait(std::bind(
+        &connection_handler::send_staff, this, std::placeholders::_1));
+    tqueue.push(timer());
+    async_write(s, boost::asio::mutable_buffers_1(send_buf, 32), std::bind(
+        &connection_handler::stub, this, std::placeholders::_1));
+  }
 
-    void send_staff(const boost::system::error_code &e) {
-        // std::cout << "send_staff\n";
-        assert(!e);
-        if(errored) return;
-        exch_tmr.expires_from_now(boost::posix_time::microseconds(rand() % (2 * send_each_mcs)));
-        exch_tmr.async_wait(std::bind(&connection_handler::send_staff, this, std::placeholders::_1));
-        tqueue.push(timer());
-        async_write(s, boost::asio::mutable_buffers_1(send_buf, 32), std::bind(&connection_handler::stub, this, std::placeholders::_1));
+  void stub(const boost::system::error_code& e) {
+    if (errored) {
+      return;
     }
-
-    void stub(const boost::system::error_code &e) {
-        // std::cout << "stub\n";
-        if(errored) return;
-        if(e) {
-            // cerr << "send error\n";
-            errored = true;
-            __sync_fetch_and_add(&exchange_errors, 1);
-            return;
-        }
+    if (e) {
+      errored = true;
+      ++exchange_errors;
+      return;
     }
+  }
 
-    void read_staff(const boost::system::error_code &e) {
-        // std::cout << "read_staff\n";
-        if(errored) return;
-        if(e) {
-            errored = true;
-            __sync_fetch_and_add(&exchange_errors, 1);
-            return;
-        }
-        memset(read_buf, 0, 33);
-        async_read(s, boost::asio::mutable_buffers_1(read_buf, 32), std::bind(&connection_handler::compare_staff, this, std::placeholders::_1, std::placeholders::_2));
+  void read_staff(const boost::system::error_code& e) {
+    if (errored) {
+      return;
     }
-
-    void compare_staff(const boost::system::error_code &e, std::size_t transferred) {
-        // std::cout << "compare_staff\n";
-        if(errored) return;
-        if(e || transferred != 32 || strncmp(send_buf, read_buf, 32)) {
-            //if(strncmp(send_buf, read_buf, 32)) cerr << transferred << " \"" << send_buf << "\" != \"" << read_buf << "\"" << std::endl;
-            errored = true;
-            __sync_fetch_and_add(&exchange_errors, 1);
-            return;
-        }
-        std::size_t spent_mcs = tqueue.front().current();
-        tqueue.pop();
-        if(spent_mcs > client_timeout_mcs) {
-            errored = true;
-            __sync_fetch_and_add(&exchange_errors, 1);
-            return;
-        }
-        __sync_fetch_and_add(&msgs, 1);
-        __sync_fetch_and_add(&latency_summ_mcs, spent_mcs);
-        read_staff(e);
+    if (e) {
+      errored = true;
+      ++exchange_errors;
+      return;
     }
+    memset(read_buf, 0, 33);
+    async_read(s, boost::asio::mutable_buffers_1(read_buf, 32), std::bind(
+        &connection_handler::compare_staff, this, std::placeholders::_1, std::placeholders::_2));
+  }
 
-    std::size_t service_id;
-    boost::asio::io_service &my_service;
-    boost::asio::ip::tcp::socket s;
-    boost::asio::deadline_timer bear_tmr;
-    boost::asio::deadline_timer exch_tmr;
-    char send_buf[33];
-    char read_buf[33];
-    timer connect_timer;
-    timer exchange_timer;
-    bool errored;
-    std::queue<timer> tqueue;
+  void compare_staff(const boost::system::error_code& e, std::size_t transferred) {
+    if (errored) {
+      return;
+    }
+    if (e || transferred != 32 || strncmp(send_buf, read_buf, 32)) {
+      errored = true;
+      ++exchange_errors;
+      return;
+    }
+    std::size_t spent_mcs = tqueue.front().current();
+    tqueue.pop();
+    if (spent_mcs > client_timeout_mcs) {
+      errored = true;
+      ++exchange_errors;
+      return;
+    }
+    ++msgs;
+    latency_summ_mcs += spent_mcs;
+    read_staff(e);
+  }
+
+  std::size_t service_id;
+  boost::asio::io_service& my_service;
+  boost::asio::ip::tcp::socket s;
+  boost::asio::deadline_timer bear_tmr;
+  boost::asio::deadline_timer exch_tmr;
+  char send_buf[33];
+  char read_buf[33];
+  timer connect_timer;
+  bool errored;
+  std::queue<timer> tqueue;
 };
 
 void print_stat(bool final = false) {
-    if(final) std::cout << "\nFinal statistics:\n";
-    std::size_t conn_avg = connection_summ_mcs / std::max((std::size_t) children - connection_errors, (std::size_t) 1);
-    std::size_t lat_avg = latency_summ_mcs / std::max((std::size_t) msgs, (std::size_t) 1);
-    std::cout << "Chld: " << children << " ConnErr: " << (final ? connection_errors + connection_active : connection_errors) << " ExchErr: " << exchange_errors << " ConnAvg: " << (((double) conn_avg) / 1000) << "ms LatAvg: " << (((double) lat_avg) / 1000) << "ms  Msgs: " << msgs << "\n";
+  if (final) {
+    std::cout << "\nFinal statistics:\n";
+  }
+  std::size_t conn_avg = connection_summ_mcs / std::max((std::size_t) children - connection_errors, (std::size_t) 1);
+  std::size_t lat_avg = latency_summ_mcs / std::max((std::size_t) msgs, (std::size_t) 1);
+  std::cout << "Chld: " << children << " ConnErr: " << (final ? connection_errors + connection_active : static_cast<std::size_t>(connection_errors)) << " ExchErr: " << exchange_errors << " ConnAvg: " << (((double) conn_avg) / 1000) << "ms LatAvg: " << (((double) lat_avg) / 1000) << "ms  Msgs: " << msgs << "\n";
 }
 
-int main(int args, char **argv) {
-    if(args < 2) {
-        std::cout << "Usage: " << argv[0] << " <host> [port = 32000 [threads = 24]]" << std::endl;
-        return 1;
-    }
-    std::string host(argv[1]);
-    std::string port(args > 2 ? argv[2] : "32000");
-    std::string threads(args > 3 ? argv[3] : "24");
-    threads_ = atoi(threads.c_str());
-    vthreads = new std::thread[threads_];
-    services = new boost::asio::io_service[threads_];
-    for(std::size_t i = 0; i < threads_; ++i) vthreads[i] = std::thread(servicing, i);
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    std::cout << "Starting tests" << std::endl;
-    boost::asio::ip::tcp::resolver resolver(services[0]);
-    boost::asio::ip::tcp::resolver::query query(host, port);
-    connect_to = resolver.resolve(query);
-    new connection_handler;
-    for(std::size_t i = 0; i < 60; i += 5) {
-        print_stat();
-        std::this_thread::sleep_for(std::chrono::seconds(5));
-    }
-    print_stat(true);
-    return 0;
+int main(int args, char** argv) {
+  if (args < 2) {
+    std::cout << "Usage: " << argv[0] << " <host> [port = 32000 [threads = 24]]" << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::string host = argv[1];
+  std::string port = args > 2 ? argv[2] : "32000";
+  thread_num = args > 3 ? std::atoi(argv[3]) : 24;
+  std::vector<std::thread> threads;
+  threads.reserve(thread_num);
+  services.reserve(thread_num);
+  for(std::size_t i = 0; i < thread_num; ++i) {
+    services.emplace_back(std::make_unique<boost::asio::io_service>(1));
+    threads.emplace_back([i] {
+      boost::asio::io_service::work worker(*services[i]);
+      services[i]->run();
+    });
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  std::cout << "Starting tests" << std::endl;
+  boost::asio::ip::tcp::resolver resolver(*services[0]);
+  boost::asio::ip::tcp::resolver::query query(host, port);
+  connect_to = resolver.resolve(query);
+  new connection_handler;
+  for (std::size_t i = 0; i < 60; i += 5) {
+    print_stat();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+  }
+  print_stat(true);
+  return EXIT_SUCCESS;
 }

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -16,7 +16,7 @@ namespace {
 const std::size_t clients_max = 10000;
 const std::size_t bear_after_mcs = 1000;
 const std::size_t send_each_mcs = 10000;
-const std::size_t client_timeout_mcs = 30*1000*1000;
+const std::size_t client_timeout_mcs = 30 * 1000 * 1000;
 
 std::size_t thread_num;
 

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -391,7 +391,7 @@ void print_stat(bool final = false) {
 
 int main(int args, char** argv) {
   if (args < 2) {
-    std::cout << "Usage: " << argv[0] << " <host> [port = 32000 [threads = 24]]" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " <host> [port = 32000 [threads = 24]]" << std::endl;
     return EXIT_FAILURE;
   }
   std::string host = argv[1];

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -380,7 +380,7 @@ private:
 
 void print_stat(bool final = false) {
   if (final) {
-    std::cout << "\nFinal statistics:\n";
+    std::cout << "\nFinal statistics: ";
   }
   std::size_t conn_avg = connection_sum_mcs / (std::max)((std::size_t) children - connection_errors, (std::size_t) 1);
   std::size_t lat_avg = latency_sum_mcs / (std::max)((std::size_t) msgs, (std::size_t) 1);

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -380,7 +380,7 @@ private:
 
 void print_stat(bool final = false) {
   if (final) {
-    std::cout << "\nFinal statistics: ";
+    std::cout << "\nFinal statistics:\n";
   }
   std::size_t conn_avg = connection_sum_mcs / (std::max)((std::size_t) children - connection_errors, (std::size_t) 1);
   std::size_t lat_avg = latency_sum_mcs / (std::max)((std::size_t) msgs, (std::size_t) 1);

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -203,8 +203,9 @@ int main(int args, char** argv) {
   }
   std::string host = argv[1];
   std::string port = args > 2 ? argv[2] : "32000";
-  thread_num = args > 3 ? std::atoi(argv[3]) : 24;
-  std::mt19937 rand_engine;
+  thread_num = static_cast<std::size_t>(args > 3 ? std::atol(argv[3]) : 24);
+  std::random_device random_device;
+  std::mt19937 rand_engine(random_device());
   std::vector<std::thread> threads;
   threads.reserve(thread_num);
   services.reserve(thread_num);

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -7,7 +7,7 @@
 #include <type_traits>
 #include <chrono>
 #include <memory>
-#include <memory>
+#include <array>
 #include <cstdlib>
 #include <random>
 #include <algorithm>

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -32,28 +32,26 @@ std::atomic_size_t latency_summ_mcs(0);
 std::atomic_size_t msgs(0);
 
 class timer {
-  public:
-    timer() {
-      reset(); 
-    }
+public:
+  timer() {
+    reset();
+  }
 
-    void start() { 
-      gettimeofday(&start_time, NULL); 
-    }
+  void start() {
+    start_time = std::chrono::steady_clock::now();
+  }
 
-    std::size_t current() {
-      struct timeval now;
-      gettimeofday(&now, NULL);
-      std::size_t diff = (((std::size_t) now.tv_sec) * 1000000) + now.tv_usec - (((std::size_t) start_time.tv_sec) * 1000000) - start_time.tv_usec;
-      return diff;
-    }
+  std::size_t current() {
+    auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(now - start_time).count();
+  }
 
-    void reset() {
-      start();
-    }
+  void reset() {
+    start();
+  }
 
-  private:
-    struct timeval start_time;
+private:
+  std::chrono::steady_clock::time_point start_time;
 };
 
 struct connection_handler {

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -192,7 +192,7 @@ int main(int args, char** argv) {
   }
   std::string host = argv[1];
   std::string port = args > 2 ? argv[2] : "32000";
-  thread_num = static_cast<std::size_t>(args > 3 ? std::atoi(argv[3]) : 24);
+  thread_num = args > 3 ? std::atoi(argv[3]) : 24;
   std::vector<std::thread> threads;
   threads.reserve(thread_num);
   services.reserve(thread_num);

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <memory>
 #include <cstdlib>
+#include <random>
 #include <algorithm>
 #include <boost/asio.hpp>
 
@@ -39,12 +40,12 @@ public:
   }
 
   void start() {
-    start_time = std::chrono::steady_clock::now();
+    start_time_ = std::chrono::steady_clock::now();
   }
 
-  std::size_t current() {
+  std::size_t current() const {
     auto now = std::chrono::steady_clock::now();
-    return std::chrono::duration_cast<std::chrono::microseconds>(now - start_time).count();
+    return std::chrono::duration_cast<std::chrono::microseconds>(now - start_time_).count();
   }
 
   void reset() {
@@ -52,112 +53,115 @@ public:
   }
 
 private:
-  std::chrono::steady_clock::time_point start_time;
+  std::chrono::steady_clock::time_point start_time_;
 };
 
 class connection_handler : public std::enable_shared_from_this<connection_handler> {
 public:
-  connection_handler() :
-    service_id(++services_i),
-    my_service(*services[service_id % thread_num]),
-    s(my_service),
-    bear_tmr(my_service, boost::posix_time::microseconds(bear_after_mcs)),
-    exch_tmr(my_service),
-    errored(false) {}
+  explicit connection_handler(const std::mt19937& rand_engine) :
+    service_id_(++services_i),
+    my_service_(*services[service_id_ % thread_num]),
+    socket_(my_service_),
+    bear_timer_(my_service_, boost::posix_time::microseconds(bear_after_mcs)),
+    exch_timer_(my_service_),
+    errored_(false),
+    rand_engine_(rand_engine),
+    data_rand_(0, RAND_MAX),
+    exch_rand_(0, 2 * send_each_mcs) {}
 
   void start() {
-    if (service_id >= clients_max) {
+    if (service_id_ >= clients_max) {
       return;
     }
-    bear_tmr.async_wait(std::bind(
+    bear_timer_.async_wait(std::bind(
         &connection_handler::new_connection_handler, shared_from_this(), std::placeholders::_1));
-    connect_timer.reset();
+    connect_timer_.reset();
     ++connection_active;
-    boost::asio::async_connect(s, connect_to, std::bind(
+    boost::asio::async_connect(socket_, connect_to, std::bind(
         &connection_handler::connect, shared_from_this(), std::placeholders::_1));
   }
 
 private:
   void new_connection_handler(const boost::system::error_code& e) {
     assert(!e);
-    std::make_shared<connection_handler>()->start();
+    std::make_shared<connection_handler>(rand_engine_)->start();
   }
 
   void connect(const boost::system::error_code& e) {
     ++children;
     --connection_active;
     if (e) {
-      errored = true;
+      errored_ = true;
       ++connection_errors;
       return;
     }
-    std::size_t spent_mcs = connect_timer.current();
+    std::size_t spent_mcs = connect_timer_.current();
     if (spent_mcs > client_timeout_mcs) {
-      errored = true;
+      errored_ = true;
       ++connection_errors;
       return;
     }
     connection_summ_mcs += spent_mcs;
-    memset(send_buf, ' ', 32);
-    snprintf(send_buf, 32, "%d", rand());
-    send_buf[31] = '\n';
-    send_buf[32] = 0;
-    s.set_option(boost::asio::ip::tcp::no_delay(true));
+    memset(send_buf_, ' ', 32);
+    snprintf(send_buf_, 32, "%d", data_rand_(rand_engine_));
+    send_buf_[31] = '\n';
+    send_buf_[32] = 0;
+    socket_.set_option(boost::asio::ip::tcp::no_delay(true));
     read_staff(boost::system::error_code());
     send_staff(boost::system::error_code());
   }
 
   void send_staff(const boost::system::error_code& e) {
     assert(!e);
-    if (errored) {
+    if (errored_) {
       return;
     }
-    exch_tmr.expires_from_now(boost::posix_time::microseconds(rand() % (2 * send_each_mcs)));
-    exch_tmr.async_wait(std::bind(
+    exch_timer_.expires_from_now(boost::posix_time::microseconds(exch_rand_(rand_engine_) % (2 * send_each_mcs)));
+    exch_timer_.async_wait(std::bind(
         &connection_handler::send_staff, shared_from_this(), std::placeholders::_1));
-    tqueue.push(timer());
-    boost::asio::async_write(s, boost::asio::mutable_buffers_1(send_buf, 32), std::bind(
+    tqueue_.push(timer());
+    boost::asio::async_write(socket_, boost::asio::mutable_buffers_1(send_buf_, 32), std::bind(
         &connection_handler::stub, shared_from_this(), std::placeholders::_1));
   }
 
   void stub(const boost::system::error_code& e) {
-    if (errored) {
+    if (errored_) {
       return;
     }
     if (e) {
-      errored = true;
+      errored_ = true;
       ++exchange_errors;
       return;
     }
   }
 
   void read_staff(const boost::system::error_code& e) {
-    if (errored) {
+    if (errored_) {
       return;
     }
     if (e) {
-      errored = true;
+      errored_ = true;
       ++exchange_errors;
       return;
     }
-    memset(read_buf, 0, 33);
-    boost::asio::async_read(s, boost::asio::mutable_buffers_1(read_buf, 32), std::bind(
+    memset(read_buf_, 0, 33);
+    boost::asio::async_read(socket_, boost::asio::mutable_buffers_1(read_buf_, 32), std::bind(
         &connection_handler::compare_staff, shared_from_this(), std::placeholders::_1, std::placeholders::_2));
   }
 
   void compare_staff(const boost::system::error_code& e, std::size_t transferred) {
-    if (errored) {
+    if (errored_) {
       return;
     }
-    if (e || transferred != 32 || strncmp(send_buf, read_buf, 32)) {
-      errored = true;
+    if (e || transferred != 32 || strncmp(send_buf_, read_buf_, 32)) {
+      errored_ = true;
       ++exchange_errors;
       return;
     }
-    std::size_t spent_mcs = tqueue.front().current();
-    tqueue.pop();
+    std::size_t spent_mcs = tqueue_.front().current();
+    tqueue_.pop();
     if (spent_mcs > client_timeout_mcs) {
-      errored = true;
+      errored_ = true;
       ++exchange_errors;
       return;
     }
@@ -166,24 +170,27 @@ private:
     read_staff(e);
   }
 
-  std::size_t service_id;
-  boost::asio::io_service& my_service;
-  boost::asio::ip::tcp::socket s;
-  boost::asio::deadline_timer bear_tmr;
-  boost::asio::deadline_timer exch_tmr;
-  char send_buf[33];
-  char read_buf[33];
-  timer connect_timer;
-  bool errored;
-  std::queue<timer> tqueue;
+  std::size_t service_id_;
+  boost::asio::io_service& my_service_;
+  boost::asio::ip::tcp::socket socket_;
+  boost::asio::deadline_timer bear_timer_;
+  boost::asio::deadline_timer exch_timer_;
+  char send_buf_[33];
+  char read_buf_[33];
+  timer connect_timer_;
+  bool errored_;
+  std::queue<timer> tqueue_;
+  std::mt19937 rand_engine_;
+  std::uniform_int_distribution<int> data_rand_;
+  std::uniform_int_distribution<int> exch_rand_;
 };
 
 void print_stat(bool final = false) {
   if (final) {
     std::cout << "\nFinal statistics:\n";
   }
-  std::size_t conn_avg = connection_summ_mcs / std::max((std::size_t) children - connection_errors, (std::size_t) 1);
-  std::size_t lat_avg = latency_summ_mcs / std::max((std::size_t) msgs, (std::size_t) 1);
+  std::size_t conn_avg = connection_summ_mcs / (std::max)((std::size_t) children - connection_errors, (std::size_t) 1);
+  std::size_t lat_avg = latency_summ_mcs / (std::max)((std::size_t) msgs, (std::size_t) 1);
   std::cout << "Chld: " << children << " ConnErr: " << (final ? connection_errors + connection_active : static_cast<std::size_t>(connection_errors)) << " ExchErr: " << exchange_errors << " ConnAvg: " << (((double) conn_avg) / 1000) << "ms LatAvg: " << (((double) lat_avg) / 1000) << "ms  Msgs: " << msgs << "\n";
 }
 
@@ -197,6 +204,7 @@ int main(int args, char** argv) {
   std::string host = argv[1];
   std::string port = args > 2 ? argv[2] : "32000";
   thread_num = args > 3 ? std::atoi(argv[3]) : 24;
+  std::mt19937 rand_engine;
   std::vector<std::thread> threads;
   threads.reserve(thread_num);
   services.reserve(thread_num);
@@ -212,7 +220,7 @@ int main(int args, char** argv) {
   boost::asio::ip::tcp::resolver resolver(*services[0]);
   boost::asio::ip::tcp::resolver::query query(host, port);
   connect_to = resolver.resolve(query);
-  std::make_shared<connection_handler>()->start();
+  std::make_shared<connection_handler>(rand_engine)->start();
   for (std::size_t i = 0; i < 60; i += 5) {
     print_stat();
     std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/client-c++-virtan/client.cc
+++ b/client-c++-virtan/client.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <memory>
 #include <cstdlib>
+#include <algorithm>
 #include <boost/asio.hpp>
 
 namespace {
@@ -213,6 +214,10 @@ int main(int args, char** argv) {
     print_stat();
     std::this_thread::sleep_for(std::chrono::seconds(5));
   }
+  std::for_each(services.begin(), services.end(), [](std::unique_ptr<boost::asio::io_service>& s) {
+    s->stop();
+  });
+  std::for_each(threads.begin(), threads.end(), std::mem_fn(&std::thread::join));
   print_stat(true);
   return EXIT_SUCCESS;
 }

--- a/client-c++-virtan/test.sh
+++ b/client-c++-virtan/test.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+if [[ "$#" -lt 2 ]]; then
+  echo "Usage: $0 host port [number-of-threads = 24 [number-of-iteration = 16 [client-docker-image]]]" >&2
+  exit 1
+fi
+
+target_host="${1}"
+target_port=${2}
+
+if [[ "$#" -ge 3 ]]; then
+  work_threads=${3}
+else
+  work_threads=24
+fi
+
+if [[ "$#" -ge 4 ]]; then
+  run_iterations=${4}
+else
+  run_iterations=16
+fi
+
+if [[ "$#" -ge 5 ]]; then
+  docker_image="${5}"
+else
+  docker_image="abrarov/client-cpp-virtan"
+fi
+
+max_msgs=0
+best_stats=""
+
+echo "Running container from ${docker_image} image ${run_iterations} times with command: ${target_host} ${target_port} ${work_threads}"
+
+i=0
+while [[ ${i} -lt ${run_iterations} ]]
+do
+  #echo "Running iteration #${i}..."
+  stats=$(docker run --rm ${docker_image} ${target_host} ${target_port} ${work_threads} 2>&1 | grep -A 1 "Final statistics" | grep "Chld:")
+  #echo "Stats: ${stats}"
+  msgs=$(echo "${stats}" | sed -r 's/.*Msgs: ([0-9]+)/\1/')
+  if [[ "${msgs}" -gt ${max_msgs} ]]; then
+    max_msgs=${msgs}
+    best_stats="${stats}"
+  fi
+  i=$(( ${i} + 1 ))
+done
+
+echo "Best stats: ${best_stats}"


### PR DESCRIPTION
test client:

* Asio custom handler allocation
* replaced C standard library functions with C++11 standard library classes and functions
* preallocation of client data
* fixed work with Asio composed operations
* imidiate stop of test when time is out
* shell script to run tests multiple times
* Asio concurrency hint for reduction of thread locking
* `boost::numeric_cast` when transforming integral types
* reformatting and renaming

c++-virtan server:

* Asio concurrency hint for reduction of thread locking
* `std::array` instead of raw array for data buffer
* `boost::numeric_cast` when transforming integral types